### PR TITLE
Docker周り、最新のrequirements.txtへの対応とtypo修正＆ReadmeにDockerでのenterBot起動方法を追記

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,18 @@
-FROM alpine:edge
+FROM python:3.8.5-slim-buster
+# FROM alpine:edge
 
 # Add project source
 WORKDIR /usr/src/discord.study
 COPY . ./
 
 # Install dependencies
-RUN apk update \
-&& apk add --no-cache \
-  ca-certificates \
-  python3 \
-  py-pip \
-  python3-dev \
-  bash \
-\
-# Install build dependencies
-&& apk add --no-cache --virtual .build-deps \
-  gcc \
-  git \
-  libffi-dev \
-  make \
-  musl-dev \
-\
-# Install pip dependencies
-&& pip install --no-cache-dir -r requirements.txt \
-\
-# Clean up build dependencies
-&& apk del .build-deps
+RUN apt update \
+  && apt-get -y install procps \
+  && apt-get -y clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install --upgrade pip \
+  && pip install --no-cache-dir -r requirements.txt \
+  && pip install -U "discord.py[voice]"
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/usr/src/discord.study/entry_exit/observer.sh"]

--- a/README.MD
+++ b/README.MD
@@ -23,3 +23,48 @@ BEGIN
     UPDATE mem_time SET modifeid_datetime = datetime('now', 'localtime') WHERE userid = OLD.userid ;
 END;
 ```
+
+
+## Docker上でenterBotを動かす
+
+- 試した環境
+```
+macOS 10.15.x
+docker 2.3.0.3
+```
+
+- 現状対応しているのは
+enterBot(enter_exit)のみ
+botの起動
+
+
+- Clone
+```
+git clone git@github.com:mo9mo9study/discord.study.git
+cd discord.study
+```
+
+- .envにDiscordへの接続情報を書き込む
+
+```
+cp -i $(pwd)/entry_exit/env_vars/{.env.default,.env}
+```
+$(pwd)/entry_exit/env_vars/.env にテスト用DiscordサーバのTokenなどを記入する。
+DiscordサーバやTokenの用意方法などはいつかまとめるかもしれないし、まとめないかもしれない。わからなければもくもくOnline勉強会で聞いてください。
+
+
+- Docker imageをbuildしてenterBotを起動
+```
+docker build . -t discord.study
+docker run -v $(pwd)/entry_exit/env_vars:/dotfiles -itd discord.study
+docker ps # discord.studyが上がっていればok
+```
+
+- 起動したDocker imageのbashでログインしてbotのログを見る
+```
+docker exec -it $(docker ps -lq) bash  
+or
+docker exec -it $(docker ps|grep discord.study|awk -F' ' '{print $1}') bash  
+```
+この状態でDiscordサーバの音声チャネルに入退室すると、それを検知したenterBotがログを標準出力に出力します。
+

--- a/entry_exit/observer.sh
+++ b/entry_exit/observer.sh
@@ -9,7 +9,7 @@ ENTER_BOT_LOG_DIR=$(pwd)/logs/enterBot # /var/log/discord/enterBot
 if [ ! -e ${ENTER_BOT_LOG_DIR} ]; then
     mkdir -p ${ENTER_BOT_LOG_DIR}
 fi
-TIME_LOG_DIR==${pwd}/timelog
+TIME_LOG_DIR=$(pwd)/timelog
 if [ ! -e ${TIME_LOG_DIR} ]; then
     mkdir -p ${TIME_LOG_DIR}
 fi
@@ -23,8 +23,8 @@ fi
 if [ ${strStatus} -eq 1 ]; then
     # source ${ENTER_BOT_BASE_DIR}/entry_exit/.env
     source /dotfiles/.env
-    /usr/bin/python3 ${ENTER_BOT_BASE_DIR}/entry_exit/enter_exit_bot.py & 1>> ${ENTER_BOT_LOG_DIR}/success.log 2>> ${ENTER_BOT_LOG_DIR}/error.log
-    echo "${today} - bot not found. restart." >> ${ENTER_BOT_LOG_DIR}/observer.log
+    python3 ${ENTER_BOT_BASE_DIR}/entry_exit/enter_exit_bot.py & 1>> ${ENTER_BOT_LOG_DIR}/success.log 2>> ${ENTER_BOT_LOG_DIR}/error.log
+    echo "${today} - bot not found. start or restart." >> ${ENTER_BOT_LOG_DIR}/observer.log
 elif [ ${strStatus} -ne 0 -o ${strStatus} -ne 1 ]; then
     echo "${today} - OK!" >> ${ENTER_BOT_LOG_DIR}/observer.log
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ cffi==1.14.0
 chardet==3.0.4
 colorful==0.5.4
 colorlog==4.1.0
+discord==1.0.1
 discord.py==1.3.4
 ffmpeg-python==0.2.0
 future==0.18.2


### PR DESCRIPTION
1. 下記requirements.txt変更によりNumPyなど重めのパッケージが追加されたため、DockerのbaseimageをAlpineからSlimに差し替えました。*Alpineだとビルド＆メンテが辛いのと、Docker imageが大きくなってしまうため
https://github.com/mo9mo9study/discord.study/commit/63da73ecffc5c6d08f4749a2e91637bb5dd86202#diff-b4ef698db8ca845e5845c4618278f29a
2. observe.shのtypo修正
3. ReadmeにDockerでのenterBot起動方法を追記