### PR TITLE
Feature/report classified study time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
 FROM python:3.8.5-slim-buster
-# FROM alpine:edge
 
 # Add project source
 WORKDIR /usr/src/discord.study
-COPY . ./
 
 # Install dependencies
 RUN apt update \
-  && apt-get -y install procps \
+  && apt-get -y install procps python3-magic \
+  && apt-get -y install vim \
   && apt-get -y clean \
-  && rm -rf /var/lib/apt/lists/* \
-  && pip install --upgrade pip \
+  && rm -rf /var/lib/apt/lists/* 
+
+# Add project source
+COPY . ./
+
+RUN pip install --upgrade pip \
   && pip install --no-cache-dir -r requirements.txt \
   && pip install -U "discord.py[voice]"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /usr/src/discord.study
 
 # Install dependencies
 RUN apt update \
-  && apt-get -y install procps \
+  && apt-get -y install procps python3-magic \
+  && apt-get -y install vim \
   && apt-get -y clean \
   && rm -rf /var/lib/apt/lists/* 
 

--- a/entry_exit/observer.sh
+++ b/entry_exit/observer.sh
@@ -1,11 +1,6 @@
 #!/bin/sh
-<<<<<<< HEAD
-bash $(pwd)/entry_exit/enter_exit_bot.sh
-#bash post_week_result.sh
-=======
 bash $(pwd)/entry_exit/enter_exit_bot.sh &
 bash $(pwd)/entry_exit/post_week_result.sh &
->>>>>>> update observe.sh
 while :; do
     sleep 1
 done

--- a/entry_exit/observer.sh
+++ b/entry_exit/observer.sh
@@ -1,33 +1,6 @@
 #!/bin/sh
-ps -ef |grep -v grep |grep enter_exit_bot.py
-strStatus=$(echo $?)
-today=$(date "+%Y/%m/%d/%H:%M:%S")
-
-# initialize
-ENTER_BOT_BASE_DIR=$(pwd) # /home/ec2-user/discord
-ENTER_BOT_LOG_DIR=$(pwd)/logs/enterBot # /var/log/discord/enterBot
-if [ ! -e ${ENTER_BOT_LOG_DIR} ]; then
-    mkdir -p ${ENTER_BOT_LOG_DIR}
-fi
-TIME_LOG_DIR=$(pwd)/timelog
-if [ ! -e ${TIME_LOG_DIR} ]; then
-    mkdir -p ${TIME_LOG_DIR}
-fi
-
-# validation
-# if [ ! -f /dotfiles/.env ] then
-#     echo "${ENTER_BOT_BASE_DIR}/entry_exit/env_vars/.env is not found."
-#     echo "Could you create ./entry_exit/env_vars/.env?  You can see sample via ./entry_exit/env_vars/.env.default"
-# fi
-
-if [ ${strStatus} -eq 1 ]; then
-    # source ${ENTER_BOT_BASE_DIR}/entry_exit/.env
-    source /dotfiles/.env
-    python3 ${ENTER_BOT_BASE_DIR}/entry_exit/enter_exit_bot.py & 1>> ${ENTER_BOT_LOG_DIR}/success.log 2>> ${ENTER_BOT_LOG_DIR}/error.log
-    echo "${today} - bot not found. start or restart." >> ${ENTER_BOT_LOG_DIR}/observer.log
-elif [ ${strStatus} -ne 0 -o ${strStatus} -ne 1 ]; then
-    echo "${today} - OK!" >> ${ENTER_BOT_LOG_DIR}/observer.log
-fi
+bash $(pwd)/entry_exit/enter_exit_bot.sh &
+bash $(pwd)/entry_exit/post_week_result.sh &
 while :; do
     sleep 1
 done

--- a/entry_exit/observer.sh
+++ b/entry_exit/observer.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
+<<<<<<< HEAD
 bash $(pwd)/entry_exit/enter_exit_bot.sh
 #bash post_week_result.sh
+=======
+bash $(pwd)/entry_exit/enter_exit_bot.sh &
+bash $(pwd)/entry_exit/post_week_result.sh &
+>>>>>>> update observe.sh
 while :; do
     sleep 1
 done

--- a/entry_exit/post_week_result.sh
+++ b/entry_exit/post_week_result.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+ps -ef |grep -v grep | grep -v 'vi ' |grep post_week_result.py
+strStatus=$(echo $?)
+today=$(date "+%Y/%m/%d/%H:%M:%S")
+
+# initialize
+BOT_BASE_DIR=$(pwd) # /home/ec2-user/discord
+BOT_LOG_DIR=$(pwd)/logs/post_week_result # /var/log/discord/enterBot
+if [ ! -e ${BOT_LOG_DIR} ]; then
+    mkdir -p ${BOT_LOG_DIR}
+fi
+TIME_LOG_DIR=$(pwd)/entry_exit/timelog
+if [ ! -e ${TIME_LOG_DIR} ]; then
+    mkdir -p ${TIME_LOG_DIR}
+fi
+USER_SETTINGS_DIR=$(pwd)/entry_exit/userSettings
+if [ ! -e ${USER_SETTINGS_DIR} ]; then
+    mkdir -p ${USER_SETTINGS_DIR}
+fi
+
+# validation
+# if [ ! -f /dotfiles/.env ] then
+#     echo "${BOT_BASE_DIR}/entry_exit/env_vars/.env is not found."
+#     echo "Could you create ./entry_exit/env_vars/.env?  You can see sample via ./entry_exit/env_vars/.env.default"
+# fi
+
+if [ ${strStatus} -eq 1 ]; then
+    # source ${BOT_BASE_DIR}/entry_exit/.env
+    source ${BOT_BASE_DIR}/entry_exit/env_vars/.env
+    python3 ${BOT_BASE_DIR}/entry_exit/post_week_result.py & 1>> ${BOT_LOG_DIR}/success.log 2>> ${BOT_LOG_DIR}/error.log
+    echo "${today} - bot not found. start or restart." >> ${BOT_LOG_DIR}/observer.log
+elif [ ${strStatus} -ne 0 -o ${strStatus} -ne 1 ]; then
+    echo "${today} - OK!" >> ${BOT_LOG_DIR}/observer.log
+fi
+while :; do
+    sleep 1
+done

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ colorful==0.5.4
 colorlog==4.1.0
 discord==1.0.1
 discord.py==1.3.4
+emoji==0.5.4
 ffmpeg-python==0.2.0
 future==0.18.2
 idna==2.8


### PR DESCRIPTION
勉強ターゲットリストの表示と選択まで実装


勉強ターゲットリストファイル(作成機能は未実装なので開発中はとりあえず手で作ればok
```
entry_exit/userSettings/${user名}

e.g) 1行に1勉強ターゲット
AWS-SAA
AWS-SAP
```

¥studyで上記リストの一覧メッセージがポストされるので、該当するリアクションをすると勉強ターゲットが選択される

選択された勉強ターゲットは下記に記録される
```
entry_exit/userSettings/${user名}-selected 

e.g)
AWS-SAP
```

^を時間記録ログにも記載してやれば集計で使えるはず

