### PR TITLE
Remove on_reaction_add and some code for the study_target from post_week_result.

### DIFF
--- a/entry_exit/post_week_result.py
+++ b/entry_exit/post_week_result.py
@@ -27,7 +27,6 @@ SERVER = setting.dServer
 LOG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "timelog")
 USER_SETTINGS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "userSettings")
 MAX_SEND_MESSAGE_LENGTH = 2000
-ALLOWED_REACTION_LIST = [':one:', ':two:', ':three:', ':four:', ':five:', ':six:', ':seven:', ':eight:', ':nine:', ':keycap_ten:']
 
 #tag:month
 def getMonth(y, m):
@@ -385,115 +384,11 @@ async def Month_Result(ctx):
         await channel.send(month_result)
 
 
-#=======================
-# select studing target
-#=======================
 def print_trace_message(ctx, caller):
     print(os.path.basename(__file__), '->', caller)
     print("-----------")
     pprint(vars(ctx))
     print("===========")
-
-
-def build_study_list_message(targetList):
-    if (len(targetList) > 0):
-        cnt = 0
-        options = ''
-        for target in targetList:
-            options += '> ' + ALLOWED_REACTION_LIST[cnt] + ' : ' + target
-            cnt+=1
-        options = options.rstrip("\n")
-        message = '''
-> ====================
-> [ 勉強する対象を選んでね。このメッセージに勉強したいアイテムのリアクションをつければok。*複数つけても最初のものが選択されます。 ]
-{options}   
-> ====================
-        '''.format(options=options).strip()
-
-    else:
-        message = '''
-> ====================
-> 勉強中のものはなかったよ。追加してもよい？
-> 追加するなら ¥s add で追加してね。
-> ====================
-        '''
-    return message
-
-# 勉強対象一覧をlistで返す
-def list_study_target(user_name):
-    # 初回実行ならユーザ用勉強対象設定ファイルを作成するよ
-    listFile = USER_SETTINGS_DIR + '/' + user_name
-    isFirstTime = os.path.isfile(listFile)
-    if not isFirstTime:
-        with open(listFile,"w"):pass
-    targetList = open(listFile,"r").readlines()
-    return targetList
-
-# アクティブな勉強対象をセットする
-def selectStudyTarget(user_name, selected):
-    studyTargetFile = USER_SETTINGS_DIR + '/' + user_name + '-selected'
-    # 初回実行ならユーザ用勉強対象設定ファイルを作成するよ
-    isFirstTime = os.path.isfile(studyTargetFile)
-    if not isFirstTime:
-        with open(studyTargetFile,"w"):pass
-    with open(studyTargetFile, "w", encoding="utf-8") as f:
-        f.write(selected)
-        f.close
-
-
-
-
-
-
-@bot.group(invoke_without_command=True)
-async def s(ctx):
-    #当日分の日次集計
-    print_trace_message(ctx, sys._getframe().f_code.co_name)
-    targetList = list_study_target(ctx.author.name)
-    pprint(len([]))
-    pprint(len(targetList))
-    message = build_study_list_message(targetList)
-    await ctx.send(message)
-
-@bot.group(invoke_without_command=True)
-async def study(ctx):
-    #当日分の日次集計
-    print_trace_message(ctx, sys._getframe().f_code.co_name)
-    targetList = list_study_target(ctx.author.name)
-    pprint(len([]))
-    pprint(len(targetList))
-    message = build_study_list_message(targetList)
-    await ctx.send(message)
-
-
-
-@bot.event
-async def on_reaction_add(reaction, user):
-    dprint(reaction)
-    dprint(user)
-    # 素直にこちらでやったほうが良さそう
-    dprint(user.name)
-    dprint(reaction.emoji)
-    userReaction = emoji.demojize(reaction.emoji, use_aliases=True)
-    # リアクションが勉強アイテムに対応するものかを判定する
-    targetList = list_study_target(user.name)
-    studyOptions = ALLOWED_REACTION_LIST[0:len(targetList)]
-    if (userReaction in studyOptions):
-        dprint('selected: ' + reaction.emoji)
-        selectedStudyTarget = list_study_target(user.name)[studyOptions.index(userReaction)].rstrip("\n")
-        dprint(selectedStudyTarget)
-        selectStudyTarget(user.name, selectedStudyTarget)
-    # 後で良いToDoギルドで利用可能なリアクション用emojiかを判定する
-
-
-
-@bot.event
-async def on_raw_reaction_add(payload):
-    # channel_id から Channel オブジェクトを取得
-    channel = client.get_channel(payload.channel_id)
-    # pprint(payload)
-    # times_*のみ対応する?
-    # userと*が一致する場合のみ対応する?
 
 
 def dprint(msg):


### PR DESCRIPTION
# 概要
https://github.com/mo9mo9study/discord.study/issues/81
に記載されている「カスタム絵文字でリアクションをするとon_reaction_addのemojiパッケージを使用するコードでエラーを吐く」件に対応。
post_week_resultには該当コードは必要ないため削除した。

# テストについて
- on_reaction_add
標準emoji、カスタムemojiどちらをリアクションに使用しても問題のエラーが発生しなくなったことを確認済み

- ¥result_d
¥result_dをテストしようとしたが、timelog/{username}ファイルの適切なフォーマットがわからなかったため下記エラーが発生する状態のままでPRを出しているので注意してください。
¥result_dには変更を加えていないので、データさえあれば動くと考えられる。

```
Ignoring exception in command result_d:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/usr/src/discord.study/entry_exit/post_week_result.py", line 323, in result_d
    sum_study_time = xxx(name, strtoday)
  File "/usr/src/discord.study/entry_exit/post_week_result.py", line 266, in xxx
    lines_strip = read_file(user_log)
  File "/usr/src/discord.study/entry_exit/post_week_result.py", line 165, in read_file
    with open(file_path, "r", encoding="utf-8") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/usr/src/discord.study/entry_exit/timelog/xxx'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 903, in invoke
    await ctx.command.invoke(ctx)
  File "/usr/local/lib/python3.8/site-packages/discord/ext/commands/core.py", line 1334, in invoke
    await super().invoke(ctx)
  File "/usr/local/lib/python3.8/site-packages/discord/ext/commands/core.py", line 859, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/usr/local/lib/python3.8/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: FileNotFoundError: [Errno 2] No such file or directory: '/usr/src/discord.study/entry_exit/timelog/xxx'
```
